### PR TITLE
feat: add responsive navbars with toggler

### DIFF
--- a/nginx/html/index.html
+++ b/nginx/html/index.html
@@ -8,15 +8,23 @@
   </head>
   <body>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
-    <nav class="navbar navbar-dark bg-dark">
-        <a class="navbar-brand" href="#" style="margin-left: 10px;">
-            <img src="img/Nelsons_HiRes_Circle_Only-1.png" width="38" height="30" class="d-inline-block align-top"
-                alt="">
-            Pub-O
-        </a>
-        <a class="navbar-text me-auto" href="#">
-            V0.1
-        </a>
+    <nav class="navbar navbar-dark bg-dark navbar-expand-lg">
+        <div class="container-fluid">
+            <a class="navbar-brand" href="#" style="margin-left: 10px;">
+                <img src="img/Nelsons_HiRes_Circle_Only-1.png" width="38" height="30" class="d-inline-block align-top"
+                    alt="">
+                Pub-O
+            </a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
+                aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarNav">
+                <a class="navbar-text me-auto" href="#">
+                    V0.1
+                </a>
+            </div>
+        </div>
     </nav>
     <div class="container text-center mt-2 w-auto">
         <div class="row">

--- a/nginx/html/shifts/index.html
+++ b/nginx/html/shifts/index.html
@@ -11,14 +11,22 @@
 </head>
 
 <body>
-    <nav class="navbar navbar-dark bg-dark">
-        <a class="navbar-brand" href="../index.html" style="margin-left: 10px;">
-            <img src="../img/Nelsons_HiRes_Circle_Only-1.png" width="38" height="30" class="d-inline-block align-top"
-                alt="">
-            Pub-O</a>
-        <a class="navbar-text me-auto" href="#">
-            V0.1
-        </a>
+    <nav class="navbar navbar-dark bg-dark navbar-expand-lg">
+        <div class="container-fluid">
+            <a class="navbar-brand" href="../index.html" style="margin-left: 10px;">
+                <img src="../img/Nelsons_HiRes_Circle_Only-1.png" width="38" height="30" class="d-inline-block align-top"
+                    alt="">
+                Pub-O</a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
+                aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarNav">
+                <a class="navbar-text me-auto" href="#">
+                    V0.1
+                </a>
+            </div>
+        </div>
     </nav>
     <nav aria-label="breadcrumb" style="margin: 2%;">
         <ol class="breadcrumb">

--- a/nginx/html/stockmgnt/index.html
+++ b/nginx/html/stockmgnt/index.html
@@ -12,13 +12,21 @@
 
 <body>
     <nav class="navbar navbar-dark bg-dark navbar-expand-lg">
-        <a class="navbar-brand ms-2" href="../index.html">
-            <img src="../img/Nelsons_HiRes_Circle_Only-1.png" width="38" height="30" class="d-inline-block align-top"
-                alt="">
-            Pub-O</a>
-        <a class="navbar-text me-auto" href="#">
-            V0.1
-        </a>
+        <div class="container-fluid">
+            <a class="navbar-brand ms-2" href="../index.html">
+                <img src="../img/Nelsons_HiRes_Circle_Only-1.png" width="38" height="30" class="d-inline-block align-top"
+                    alt="">
+                Pub-O</a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
+                aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarNav">
+                <a class="navbar-text me-auto" href="#">
+                    V0.1
+                </a>
+            </div>
+        </div>
     </nav>
     <nav aria-label="breadcrumb">
         <ol class="breadcrumb mx-3 my-3">


### PR DESCRIPTION
## Summary
- make home, shifts, and stock pages responsive with Bootstrap `navbar-expand-lg`
- add navbar toggler buttons and collapse containers for navigation links

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c414d01380832e8197539dc12cf324