### PR TITLE
Fix Guinness button label spelling

### DIFF
--- a/nginx/html/stockmgnt/index.html
+++ b/nginx/html/stockmgnt/index.html
@@ -216,7 +216,7 @@
                         placeholder="Guinness">
                 </div>
                 <div class="col-md-2">
-                    <button class="btn btn-dark overflow-hidden w-100">Guinnes</button>
+                    <button class="btn btn-dark overflow-hidden w-100">Guinness</button>
                 </div>
                 <div class="col-md-auto">
                     <img src="../img/glas.png" width="30" height="30" class="d-inline-block align-top" alt="">


### PR DESCRIPTION
## Summary
- correct Guinness button text in stock management page

## Testing
- `npm test` (fails: Could not read package.json)
- `python3 -m http.server 8000` served page and verified button text via curl

------
https://chatgpt.com/codex/tasks/task_e_68c412464b1c832eabe062e6a03b3685