### PR TITLE
Fix wine glass stock calculation

### DIFF
--- a/nginx/html/js/calculateStock.js
+++ b/nginx/html/js/calculateStock.js
@@ -16,7 +16,7 @@ function calculateStock() {
     wineK = document.getElementById('InputWineKassa').value;
     wineZ = document.getElementById('InputWineZahler').value;
     wineP = Math.floor((wineZ-wineK)/6);
-    wineG = (wineZ-wineK) % 3;
+    wineG = Math.floor(((wineZ - wineK) % 6) / 3);
 
     gossK = document.getElementById('InputGosserKassa').value;
     gossZ = document.getElementById('InputGosserZahler').value;


### PR DESCRIPTION
## Summary
- Correct wine glass calculation to handle 6-bottle cycles correctly

## Testing
- `node -e "const calc=(k,z)=>Math.floor(((z-k)%6)/3); console.log('diff5',calc(0,5)); console.log('diff8',calc(0,8));"`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c411839ef4832e8ca9cbd3fea9c5d2