### PR TITLE
Reorder stock inputs and placeholders

### DIFF
--- a/nginx/html/stockmgnt/index.html
+++ b/nginx/html/stockmgnt/index.html
@@ -37,6 +37,9 @@
     <div class="container-sm mt-3">
         <div class="card mx-2">
             <div class="row mb-2">
+                <div class="col-md-2">
+                    <h5 class="text-center">Produkt</h5>
+                </div>
                 <div class="col-md-3">
                     <h5 class="text-center">Kassenstand</h5>
                 </div>
@@ -47,16 +50,14 @@
                 <div class="col-md-auto"></div>
             </div>
             <div class="row my-2">
-                <div class="col-md-3">
-                    <input type="tel" class="form-control" id="InputWineKassa" onchange="calculateStock()"
-                        placeholder="Wine">
-                </div>
-                <div class="col-md-3">
-                    <input type="tel" class="form-control" id="InputWineZahler" onchange="calculateStock()"
-                        placeholder="Wine">
-                </div>
                 <div class="col-md-2">
                     <button class="btn btn-dark overflow-hidden w-100">Wine</button>
+                </div>
+                <div class="col-md-3">
+                    <input type="tel" class="form-control" id="InputWineKassa" onchange="calculateStock()" placeholder="Kassenstand">
+                </div>
+                <div class="col-md-3">
+                    <input type="tel" class="form-control" id="InputWineZahler" onchange="calculateStock()" placeholder="Lagerstand">
                 </div>
                 <div class="col-md-auto">
                     <img src="../img/pitcher.png" width="30" height="30" class="d-inline-block align-top" alt="">
@@ -68,16 +69,14 @@
                 </div>
             </div>
             <div class="row my-2">
-                <div class="col-md-3">
-                    <input type="tel" class="form-control" id="InputGosserKassa" onchange="calculateStock()"
-                        placeholder="Gösser">
-                </div>
-                <div class="col-md-3">
-                    <input type="tel" class="form-control" id="InputGosserZahler" onchange="calculateStock()"
-                        placeholder="Gösser">
-                </div>
                 <div class="col-md-2">
                     <button class="btn btn-dark overflow-hidden w-100">Gösser</button>
+                </div>
+                <div class="col-md-3">
+                    <input type="tel" class="form-control" id="InputGosserKassa" onchange="calculateStock()" placeholder="Kassenstand">
+                </div>
+                <div class="col-md-3">
+                    <input type="tel" class="form-control" id="InputGosserZahler" onchange="calculateStock()" placeholder="Lagerstand">
                 </div>
                 <div class="col-md-auto">
                     <img src="../img/pitcher.png" width="30" height="30" class="d-inline-block align-top" alt="">
@@ -89,16 +88,14 @@
                 </div>
             </div>
             <div class="row my-2">
-                <div class="col-md-3">
-                    <input type="tel" class="form-control" id="InputCiderKassa" onchange="calculateStock()"
-                        placeholder="Cider">
-                </div>
-                <div class="col-md-3">
-                    <input type="tel" class="form-control" id="InputCiderZahler" onchange="calculateStock()"
-                        placeholder="Cider">
-                </div>
                 <div class="col-md-2">
                     <button class="btn btn-dark overflow-hidden w-100">Cider</button>
+                </div>
+                <div class="col-md-3">
+                    <input type="tel" class="form-control" id="InputCiderKassa" onchange="calculateStock()" placeholder="Kassenstand">
+                </div>
+                <div class="col-md-3">
+                    <input type="tel" class="form-control" id="InputCiderZahler" onchange="calculateStock()" placeholder="Lagerstand">
                 </div>
                 <div class="col-md-auto">
                     <img src="../img/pitcher.png" width="30" height="30" class="d-inline-block align-top" alt="">
@@ -110,16 +107,14 @@
                 </div>
             </div>
             <div class="row my-2">
-                <div class="col-md-3">
-                    <input type="tel" class="form-control" id="InputStieglKassa" onchange="calculateStock()"
-                        placeholder="Stiegl">
-                </div>
-                <div class="col-md-3">
-                    <input type="tel" class="form-control" id="InputStieglZahler" onchange="calculateStock()"
-                        placeholder="Stiegl">
-                </div>
                 <div class="col-md-2">
                     <button class="btn btn-dark overflow-hidden w-100">Stiegl</button>
+                </div>
+                <div class="col-md-3">
+                    <input type="tel" class="form-control" id="InputStieglKassa" onchange="calculateStock()" placeholder="Kassenstand">
+                </div>
+                <div class="col-md-3">
+                    <input type="tel" class="form-control" id="InputStieglZahler" onchange="calculateStock()" placeholder="Lagerstand">
                 </div>
                 <div class="col-md-auto">
                     <img src="../img/pitcher.png" width="30" height="30" class="d-inline-block align-top" alt="">
@@ -131,16 +126,14 @@
                 </div>
             </div>
             <div class="row my-2">
-                <div class="col-md-3">
-                    <input type="tel" class="form-control" id="InputThalheimKassa" onchange="calculateStock()"
-                        placeholder="Thalheim">
-                </div>
-                <div class="col-md-3">
-                    <input type="tel" class="form-control" id="InputThalheimZahler" onchange="calculateStock()"
-                        placeholder="Thalheim">
-                </div>
                 <div class="col-md-2">
                     <button class="btn btn-dark overflow-hidden w-100">Thalheim</button>
+                </div>
+                <div class="col-md-3">
+                    <input type="tel" class="form-control" id="InputThalheimKassa" onchange="calculateStock()" placeholder="Kassenstand">
+                </div>
+                <div class="col-md-3">
+                    <input type="tel" class="form-control" id="InputThalheimZahler" onchange="calculateStock()" placeholder="Lagerstand">
                 </div>
                 <div class="col-md-auto">
                     <img src="../img/pitcher.png" width="30" height="30" class="d-inline-block align-top" alt="">
@@ -152,16 +145,14 @@
                 </div>
             </div>
             <div class="row my-2">
-                <div class="col-md-3">
-                    <input type="tel" class="form-control" id="InputStaroKassa" onchange="calculateStock()"
-                        placeholder="Staro">
-                </div>
-                <div class="col-md-3">
-                    <input type="tel" class="form-control" id="InputStaroZahler" onchange="calculateStock()"
-                        placeholder="Staro">
-                </div>
                 <div class="col-md-2">
                     <button class="btn btn-dark overflow-hidden w-100">Staro</button>
+                </div>
+                <div class="col-md-3">
+                    <input type="tel" class="form-control" id="InputStaroKassa" onchange="calculateStock()" placeholder="Kassenstand">
+                </div>
+                <div class="col-md-3">
+                    <input type="tel" class="form-control" id="InputStaroZahler" onchange="calculateStock()" placeholder="Lagerstand">
                 </div>
                 <div class="col-md-auto">
                     <img src="../img/pitcher.png" width="30" height="30" class="d-inline-block align-top" alt="">
@@ -173,16 +164,14 @@
                 </div>
             </div>
             <div class="row my-2">
-                <div class="col-md-3">
-                    <input type="tel" class="form-control" id="InputKilkennyKassa" onchange="calculateStock()"
-                        placeholder="Kilkenny">
-                </div>
-                <div class="col-md-3">
-                    <input type="tel" class="form-control" id="InputKilkennyZahler" onchange="calculateStock()"
-                        placeholder="Kilkenny">
-                </div>
                 <div class="col-md-2">
                     <button class="btn btn-dark overflow-hidden w-100">Kilkenny</button>
+                </div>
+                <div class="col-md-3">
+                    <input type="tel" class="form-control" id="InputKilkennyKassa" onchange="calculateStock()" placeholder="Kassenstand">
+                </div>
+                <div class="col-md-3">
+                    <input type="tel" class="form-control" id="InputKilkennyZahler" onchange="calculateStock()" placeholder="Lagerstand">
                 </div>
                 <div class="col-md-auto">
                     <img src="../img/pitcher.png" width="30" height="30" class="d-inline-block align-top" alt="">
@@ -194,16 +183,14 @@
                 </div>
             </div>
             <div class="row my-2">
-                <div class="col-md-3">
-                    <input type="tel" class="form-control" id="InputHopHouseKassa" onchange="calculateStock()"
-                        placeholder="HopHouse">
-                </div>
-                <div class="col-md-3">
-                    <input type="tel" class="form-control" id="InputHopHouseZahler" onchange="calculateStock()"
-                        placeholder="HopHouse">
-                </div>
                 <div class="col-md-2">
                     <button class="btn btn-dark overflow-hidden w-100">Hop</button>
+                </div>
+                <div class="col-md-3">
+                    <input type="tel" class="form-control" id="InputHopHouseKassa" onchange="calculateStock()" placeholder="Kassenstand">
+                </div>
+                <div class="col-md-3">
+                    <input type="tel" class="form-control" id="InputHopHouseZahler" onchange="calculateStock()" placeholder="Lagerstand">
                 </div>
                 <div class="col-md-auto">
                     <img src="../img/pitcher.png" width="30" height="30" class="d-inline-block align-top" alt="">
@@ -215,16 +202,14 @@
                 </div>
             </div>
             <div class="row my-2">
-                <div class="col-md-3">
-                    <input type="tel" class="form-control" id="InputGuinnessKassa" onchange="calculateStock()"
-                        placeholder="Guinness">
-                </div>
-                <div class="col-md-3">
-                    <input type="tel" class="form-control" id="InputGuinnessZahler" onchange="calculateStock()"
-                        placeholder="Guinness">
-                </div>
                 <div class="col-md-2">
                     <button class="btn btn-dark overflow-hidden w-100">Guinness</button>
+                </div>
+                <div class="col-md-3">
+                    <input type="tel" class="form-control" id="InputGuinnessKassa" onchange="calculateStock()" placeholder="Kassenstand">
+                </div>
+                <div class="col-md-3">
+                    <input type="tel" class="form-control" id="InputGuinnessZahler" onchange="calculateStock()" placeholder="Lagerstand">
                 </div>
                 <div class="col-md-auto">
                     <img src="../img/glas.png" width="30" height="30" class="d-inline-block align-top" alt="">


### PR DESCRIPTION
## Summary
- Move product buttons before Kassenstand/Lagerstand inputs
- Use generic placeholders for Kassenstand and Lagerstand fields

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c419f37c08832e8764ad8d16c58b60