### PR TITLE
Display lagerstand column in summary view

### DIFF
--- a/nginx/html/js/calculateStock.js
+++ b/nginx/html/js/calculateStock.js
@@ -1,5 +1,17 @@
 function test() {
-document.getElementById('demo').innerHTML=Date();
+    document.getElementById('demo').innerHTML = Date();
+}
+
+let currentSummary = null;
+
+function getNumericValue(elementId) {
+    const element = document.getElementById(elementId);
+    if (!element) {
+        return 0;
+    }
+
+    const parsedValue = Number(element.value);
+    return Number.isFinite(parsedValue) ? parsedValue : 0;
 }
 
 function calculateStock() {
@@ -13,66 +25,78 @@ function calculateStock() {
         hopK, hopZ, hopP, hopG,
         guinK, guinZ, guinG;
 
-    wineK = document.getElementById('InputWineKassa').value;
-    wineZ = document.getElementById('InputWineZahler').value;
-    wineP = Math.floor((wineZ-wineK)/6);
+    wineK = getNumericValue('InputWineKassa');
+    wineZ = getNumericValue('InputWineZahler');
+    wineP = Math.floor((wineZ - wineK) / 6);
     wineG = Math.floor(((wineZ - wineK) % 6) / 3);
 
-    gossK = document.getElementById('InputGosserKassa').value;
-    gossZ = document.getElementById('InputGosserZahler').value;
+    gossK = getNumericValue('InputGosserKassa');
+    gossZ = getNumericValue('InputGosserZahler');
     gossP = calculatePitcher(gossK, gossZ);
     gossG = calculateGlasses(gossK, gossZ);
 
-    cidK = document.getElementById('InputCiderKassa').value;
-    cidZ = document.getElementById('InputCiderZahler').value;
+    cidK = getNumericValue('InputCiderKassa');
+    cidZ = getNumericValue('InputCiderZahler');
     cidP = calculatePitcher(cidK, cidZ);
     cidG = calculateGlasses(cidK, cidZ);
 
-    stieK = document.getElementById('InputStieglKassa').value;
-    stieZ = document.getElementById('InputStieglZahler').value;
+    stieK = getNumericValue('InputStieglKassa');
+    stieZ = getNumericValue('InputStieglZahler');
     stieP = calculatePitcher(stieK, stieZ);
     stieG = calculateGlasses(stieK, stieZ);
 
-    tahlK = document.getElementById('InputThalheimKassa').value;
-    thalZ = document.getElementById('InputThalheimZahler').value;
-    thalP = calculatePitcher(tahlK,thalZ);
-    thalG = calculateGlasses(tahlK,thalZ);
+    tahlK = getNumericValue('InputThalheimKassa');
+    thalZ = getNumericValue('InputThalheimZahler');
+    thalP = calculatePitcher(tahlK, thalZ);
+    thalG = calculateGlasses(tahlK, thalZ);
 
-    starK = document.getElementById('InputStaroKassa').value;
-    starZ = document.getElementById('InputStaroZahler').value;
-    starP = calculatePitcher(starK,starZ);
-    starG = calculateGlasses(starK,starZ);
+    starK = getNumericValue('InputStaroKassa');
+    starZ = getNumericValue('InputStaroZahler');
+    starP = calculatePitcher(starK, starZ);
+    starG = calculateGlasses(starK, starZ);
 
-    kilK = document.getElementById('InputKilkennyKassa').value;
-    kilZ = document.getElementById('InputKilkennyZahler').value;
+    kilK = getNumericValue('InputKilkennyKassa');
+    kilZ = getNumericValue('InputKilkennyZahler');
     kilP = calculatePitcher(kilK, kilZ);
     kilG = calculateGlasses(kilK, kilZ);
 
-    hopK = document.getElementById('InputHopHouseKassa').value;
-    hopZ = document.getElementById('InputHopHouseZahler').value;
+    hopK = getNumericValue('InputHopHouseKassa');
+    hopZ = getNumericValue('InputHopHouseZahler');
     hopP = calculatePitcher(hopK, hopZ);
     hopG = calculateGlasses(hopK, hopZ);
 
-    guinK = document.getElementById('InputGuinnessKassa').value;
-    guinZ = document.getElementById('InputGuinnessZahler').value;
-    guinG = Math.floor((guinZ-guinK)/5);
+    guinK = getNumericValue('InputGuinnessKassa');
+    guinZ = getNumericValue('InputGuinnessZahler');
+    guinG = Math.floor((guinZ - guinK) / 5);
+
+    currentSummary = buildSummary(
+        { name: 'Wine', stock: wineZ, pitchers: wineP, glasses: wineG },
+        { name: 'Gösser', stock: gossZ, pitchers: gossP, glasses: gossG },
+        { name: 'Cider', stock: cidZ, pitchers: cidP, glasses: cidG },
+        { name: 'Stiegl', stock: stieZ, pitchers: stieP, glasses: stieG },
+        { name: 'Thalheim', stock: thalZ, pitchers: thalP, glasses: thalG },
+        { name: 'Staro', stock: starZ, pitchers: starP, glasses: starG },
+        { name: 'Kilkenny', stock: kilZ, pitchers: kilP, glasses: kilG },
+        { name: 'Hop', stock: hopZ, pitchers: hopP, glasses: hopG },
+        { name: 'Guinness', stock: guinZ, pitchers: 0, glasses: guinG }
+    );
 
     createOutput(wineP, wineG, gossP, gossG, cidP, cidG, stieP, stieG, thalP, thalG, starP, starG, kilP, kilG, hopP, hopG, guinG);
 }
 
 function calculatePitcher(kassa, zahler) {
     let diff = zahler - kassa;
-    let pitcher = Math.floor(diff/15);
+    let pitcher = Math.floor(diff / 15);
     return pitcher;
 }
 
 function calculateGlasses(kassa, zahler) {
     let diff = zahler - kassa;
     let rest = diff % 15;
-    if(rest >= 10) {
+    if (rest >= 10) {
         return 2;
     }
-    if(rest >= 5) {
+    if (rest >= 5) {
         return 1;
     }
     else {
@@ -106,5 +130,76 @@ function createOutput(wineP, wineG, gossP, gossG, cidP, cidG, stieP, stieG, thal
     document.getElementById('hopG').textContent = hopG;
 
     document.getElementById('guinG').textContent = guinG;
-
 }
+
+function buildSummary(...items) {
+    const totals = items.reduce((accumulator, item) => {
+        accumulator.stock += item.stock ?? 0;
+        accumulator.pitchers += item.pitchers;
+        accumulator.glasses += item.glasses;
+        return accumulator;
+    }, { stock: 0, pitchers: 0, glasses: 0 });
+
+    return { items, totals };
+}
+
+function showSummary() {
+    calculateStock();
+    if (!currentSummary) {
+        return;
+    }
+
+    sessionStorage.setItem('stockSummary', JSON.stringify(currentSummary));
+    window.location.href = './summary.html';
+}
+
+function renderSummaryPage() {
+    const container = document.getElementById('summaryContent');
+    if (!container) {
+        return;
+    }
+
+    const rawData = sessionStorage.getItem('stockSummary');
+    if (!rawData) {
+        container.innerHTML = '<p class="text-danger">Keine Daten vorhanden. Bitte gehen Sie zurück und tragen Sie die Bestände ein.</p>';
+        return;
+    }
+
+    let summary;
+    try {
+        summary = JSON.parse(rawData);
+    } catch (error) {
+        container.innerHTML = '<p class="text-danger">Die Zusammenfassung konnte nicht geladen werden.</p>';
+        return;
+    }
+
+    const tableBody = document.getElementById('summaryTableBody');
+    const totalStock = document.getElementById('totalStock');
+    const totalPitchers = document.getElementById('totalPitchers');
+    const totalGlasses = document.getElementById('totalGlasses');
+
+    if (!tableBody || !totalStock || !totalPitchers || !totalGlasses) {
+        container.innerHTML = '<p class="text-danger">Die Zusammenfassung konnte nicht dargestellt werden.</p>';
+        return;
+    }
+
+    if (!summary.items || !Array.isArray(summary.items)) {
+        container.innerHTML = '<p class="text-danger">Die Zusammenfassung konnte nicht geladen werden.</p>';
+        return;
+    }
+
+    tableBody.innerHTML = summary.items.map(item => `
+        <tr>
+            <td>${item.name}</td>
+            <td>${item.stock ?? ''}</td>
+            <td>${item.pitchers}</td>
+            <td>${item.glasses}</td>
+        </tr>
+    `).join('');
+
+    totalStock.textContent = summary.totals.stock;
+    totalPitchers.textContent = summary.totals.pitchers;
+    totalGlasses.textContent = summary.totals.glasses;
+}
+
+

--- a/nginx/html/stockmgnt/index.html
+++ b/nginx/html/stockmgnt/index.html
@@ -217,6 +217,11 @@
                 </div>
                 <div class="col-md-auto"></div>
             </div>
+            <div class="row my-3">
+                <div class="col text-end">
+                    <button type="button" class="btn btn-primary" onclick="showSummary()">Bestand zusammenfassen</button>
+                </div>
+            </div>
         </div>
     </div>
 </body>

--- a/nginx/html/stockmgnt/summary.html
+++ b/nginx/html/stockmgnt/summary.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="de">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"
+        integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+        integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
+        crossorigin="anonymous"></script>
+    <script type="text/javascript" src="../js/calculateStock.js"></script>
+</head>
+
+<body onload="renderSummaryPage()">
+    <nav class="navbar navbar-dark bg-dark navbar-expand-lg">
+        <div class="container-fluid">
+            <a class="navbar-brand ms-2" href="../index.html">
+                <img src="../img/Nelsons_HiRes_Circle_Only-1.png" width="38" height="30" class="d-inline-block align-top"
+                    alt="">
+                Pub-O</a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
+                aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarNav">
+                <a class="navbar-text me-auto" href="#">
+                    V0.1
+                </a>
+            </div>
+        </div>
+    </nav>
+    <nav aria-label="breadcrumb">
+        <ol class="breadcrumb mx-3 my-3">
+            <li class="breadcrumb-item"><a href="../index.html">Home</a></li>
+            <li class="breadcrumb-item"><a href="./index.html">Stock-Helper</a></li>
+            <li class="breadcrumb-item active" aria-current="page">Zusammenfassung</li>
+        </ol>
+    </nav>
+    <div class="container-sm mt-3" id="summaryContent">
+        <div class="card mx-2">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <h5 class="mb-0">Zusammenfassung</h5>
+                <a href="./index.html" class="btn btn-outline-secondary btn-sm">Zurück</a>
+            </div>
+            <div class="card-body">
+                <div class="table-responsive">
+                    <table class="table table-striped">
+                        <thead>
+                            <tr>
+                                <th scope="col">Produkt</th>
+                                <th scope="col">Lagerstand</th>
+                                <th scope="col">Pitcher</th>
+                                <th scope="col">Gläser</th>
+                            </tr>
+                        </thead>
+                        <tbody id="summaryTableBody"></tbody>
+                        <tfoot>
+                            <tr class="fw-bold">
+                                <td>Gesamt</td>
+                                <td id="totalStock">0</td>
+                                <td id="totalPitchers">0</td>
+                                <td id="totalGlasses">0</td>
+                            </tr>
+                        </tfoot>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+
+</html>


### PR DESCRIPTION
## Summary
- add a helper to normalize numeric input before calculating the summary
- include each product's lagerstand in the summary data stored in session storage
- display the lagerstand column with aggregated totals on the summary table

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1b30930dc832e9916b12bb32d1b51