### PR TITLE
Replace 'Stiegl' label with 'Thal Dark'

### DIFF
--- a/nginx/html/js/calculateStock.js
+++ b/nginx/html/js/calculateStock.js
@@ -73,7 +73,7 @@ function calculateStock() {
         { name: 'Wine', stock: wineZ, pitchers: wineP, glasses: wineG },
         { name: 'Gösser', stock: gossZ, pitchers: gossP, glasses: gossG },
         { name: 'Cider', stock: cidZ, pitchers: cidP, glasses: cidG },
-        { name: 'Stiegl', stock: stieZ, pitchers: stieP, glasses: stieG },
+        { name: 'Thal Dark', stock: stieZ, pitchers: stieP, glasses: stieG },
         { name: 'Thalheim', stock: thalZ, pitchers: thalP, glasses: thalG },
         { name: 'Staro', stock: starZ, pitchers: starP, glasses: starG },
         { name: 'Kilkenny', stock: kilZ, pitchers: kilP, glasses: kilG },

--- a/nginx/html/stockmgnt/index.html
+++ b/nginx/html/stockmgnt/index.html
@@ -108,7 +108,7 @@
             </div>
             <div class="row my-2">
                 <div class="col-md-2">
-                    <button class="btn btn-dark overflow-hidden w-100">Stiegl</button>
+                    <button class="btn btn-dark overflow-hidden w-100">Thal Dark</button>
                 </div>
                 <div class="col-md-3">
                     <input type="tel" class="form-control" id="InputStieglKassa" onchange="calculateStock()" placeholder="Kassenstand">


### PR DESCRIPTION
### Motivation
- Align the visible UI label with the exported summary name by renaming the beer row from `Stiegl` to `Thal Dark` as requested.

### Description
- Update the button text in `nginx/html/stockmgnt/index.html` to change the displayed label from `Stiegl` to `Thal Dark`.
- Update the entry in `nginx/html/js/calculateStock.js` so the summary item previously named `Stiegl` is now `Thal Dark` while keeping the underlying input IDs (`InputStiegl*`) and data mapping intact.

### Testing
- Verified replacements with `rg -n "Stiegl|Thal Dark" -S nginx/html/stockmgnt/index.html nginx/html/js/calculateStock.js`, which found the updated occurrences successfully.
- Launched a local server with `python -m http.server 8000` and captured a Playwright screenshot of `stockmgnt/index.html`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a757fde64832eb9e10284bb17a632)